### PR TITLE
use asterisk suffix for node traversal instead of description checks (#204)

### DIFF
--- a/backend/services/embedding_service.py
+++ b/backend/services/embedding_service.py
@@ -232,7 +232,7 @@ def update_index_and_get_embeddings(nodes: List[Dict], brain_id: str) -> Dict[st
 def search_similar_nodes(
     embedding: List[float],
     brain_id: str,
-    limit: int = 5,
+    limit: int = 3,
     threshold: float = 0.5,
     high_score_threshold: float = 0.8
 ) -> List[Dict]:


### PR DESCRIPTION
## #️⃣ Related Issues

> #204

## 📝 Description of Work

>Use an asterisk (*) suffix for node traversal instead of description checks, and simplify the Cypher query.

## 💬 Review Notes (Optional)

> None
